### PR TITLE
Fix build badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![License](https://img.shields.io/github/license/sony/nnabla-rl)](LICENSE)
-[![Build status](https://github.com/nnabla/nnabla-rl/workflows/Build%20nnabla-rl/badge.svg)](https://github.com/nnabla/nnabla-rl/actions)
+[![Build status](https://github.com/sony/nnabla-rl/workflows/Build%20nnabla-rl/badge.svg)](https://github.com/sony/nnabla-rl/actions)
 
 # Deep Reinforcement Learning Library built on top of Neural Network Libraries
 


### PR DESCRIPTION
I fixed build badge url of readme. The current url indicates a wrong url.