### PR TITLE
Fix interactive-demos used in colab.

### DIFF
--- a/interactive-demos/atari.ipynb
+++ b/interactive-demos/atari.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install nnabla-rl gym[atari]"
+    "!pip install nnabla-rl"
    ]
   },
   {
@@ -58,26 +58,21 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "related-tongue",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "!bash package_install.sh"
+    "!git clone https://github.com/sony/nnabla-rl.git\n",
+    "!bash nnabla-rl/interactive-demos/package_install.sh\n",
+    "!bash nnabla-rl/interactive-demos/atari_install.sh\n",
+    "%run nnabla-rl/interactive-demos/colab_utils.py"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "signed-storm",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%run ./colab_utils.py"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bibliographic-seafood",
+   "id": "b1aad37e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,14 +185,6 @@
     "except:\n",
     "    env.close()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "driving-station",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -206,6 +193,7 @@
    "language": "python",
    "name": "python3"
   },
+  "accelerator": "GPU",
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/interactive-demos/atari_install.sh
+++ b/interactive-demos/atari_install.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Copyright 2021 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.#!/bin/sh
+
+# install gym[atari]
+pip install gym[atari]
+
+# install atari_py for using colab
+pip install atari_py==0.2.6

--- a/interactive-demos/colab_utils.py
+++ b/interactive-demos/colab_utils.py
@@ -42,3 +42,9 @@ class RenderHook(Hook):
         self._iteration_num += 1
         plt.axis('off')
         display.display(plt.gcf())
+
+    def reset(self):
+        self._image = None
+        self._iteration_num = 0
+        self._display = Display()
+        self._display.start()

--- a/interactive-demos/pendulum.ipynb
+++ b/interactive-demos/pendulum.ipynb
@@ -56,16 +56,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!bash package_install.sh"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%run ./colab_utils.py"
+    "!git clone https://github.com/sony/nnabla-rl.git\n",
+    "!bash nnabla-rl/interactive-demos/package_install.sh\n",
+    "%run nnabla-rl/interactive-demos/colab_utils.py"
    ]
   },
   {
@@ -184,6 +177,7 @@
    "language": "python",
    "name": "python3"
   },
+  "accelerator": "GPU",
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/interactive-demos/tutorial-algorithm.ipynb
+++ b/interactive-demos/tutorial-algorithm.ipynb
@@ -69,17 +69,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!bash package_install.sh"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "regular-alberta",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%run ./colab_utils.py"
+    "!git clone https://github.com/sony/nnabla-rl.git\n",
+    "!bash nnabla-rl/interactive-demos/package_install.sh\n",
+    "%run nnabla-rl/interactive-demos/colab_utils.py"
    ]
   },
   {
@@ -220,7 +212,8 @@
    "outputs": [],
    "source": [
     "env.reset()\n",
-    "nn.clear_parameters()"
+    "nn.clear_parameters()\n",
+    "render_hook.reset()"
    ]
   },
   {
@@ -230,7 +223,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "config = A.SACConfig(start_timesteps=500)"
+    "config = A.SACConfig(gpu_id=gpu_id, start_timesteps=500)"
    ]
   },
   {
@@ -278,14 +271,6 @@
     "\n",
     "See the [Algorithm catalog](https://github.com/sony/nnabla-rl/blob/master/nnabla_rl/algorithms/README.md) for the action type supported by the algorithm."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "danish-benjamin",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -294,6 +279,7 @@
    "language": "python",
    "name": "python3"
   },
+  "accelerator": "GPU",
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/interactive-demos/tutorial-envs.ipynb
+++ b/interactive-demos/tutorial-envs.ipynb
@@ -215,7 +215,7 @@
     "            q = NPF.affine(h, self._n_action, name=\"pred-q\")\n",
     "        return q\n",
     "\n",
-    "class CliffQFunctionBuilder(ModelBuilder[QFunction]):\n",
+    "class CliffQFunctionBuilder(ModelBuilder[DiscreteQFunction]):\n",
     "    def build_model(self, scope_name, env_info, algorithm_config, **kwargs):\n",
     "        return CliffQFunction(scope_name, env_info.action_dim)\n",
     "\n",

--- a/interactive-demos/tutorial-model.ipynb
+++ b/interactive-demos/tutorial-model.ipynb
@@ -62,16 +62,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!bash package_install.sh"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%run ./colab_utils.py"
+    "!git clone https://github.com/sony/nnabla-rl.git\n",
+    "!bash nnabla-rl/interactive-demos/package_install.sh\n",
+    "%run nnabla-rl/interactive-demos/colab_utils.py"
    ]
   },
   {
@@ -163,7 +156,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class MountainCarQFunctionBuilder(ModelBuilder[QFunction]):\n",
+    "class MountainCarQFunctionBuilder(ModelBuilder[DiscreteQFunction]):\n",
     "    def build_model(self, scope_name, env_info, algorithm_params, **kwargs):\n",
     "        return MountainCarQFunction(scope_name, env_info.action_dim)"
    ]
@@ -264,13 +257,6 @@
     "finally:\n",
     "    env.close()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -279,6 +265,7 @@
    "language": "python",
    "name": "python3"
   },
+  "accelerator": "GPU",
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/interactive-demos/tutorial-replay-buffer.ipynb
+++ b/interactive-demos/tutorial-replay-buffer.ipynb
@@ -68,17 +68,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!bash package_install.sh"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "animated-seeking",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%run ./colab_utils.py"
+    "!git clone https://github.com/sony/nnabla-rl.git\n",
+    "!bash nnabla-rl/interactive-demos/package_install.sh\n",
+    "%run nnabla-rl/interactive-demos/colab_utils.py"
    ]
   },
   {
@@ -256,6 +248,7 @@
    "language": "python",
    "name": "python3"
   },
+  "accelerator": "GPU",
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/interactive-demos/tutorial-solver.ipynb
+++ b/interactive-demos/tutorial-solver.ipynb
@@ -68,17 +68,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!bash package_install.sh"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "decimal-albert",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%run ./colab_utils.py"
+    "!git clone https://github.com/sony/nnabla-rl.git\n",
+    "!bash nnabla-rl/interactive-demos/package_install.sh\n",
+    "%run nnabla-rl/interactive-demos/colab_utils.py"
    ]
   },
   {
@@ -243,14 +235,6 @@
    "source": [
     "ddpg.train(env, total_iterations=50000)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "extreme-revision",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -259,6 +243,7 @@
    "language": "python",
    "name": "python3"
   },
+  "accelerator": "GPU",
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -269,7 +254,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.12"
+   "version": "3.8.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I fixed notebooks used in google colaboratory.

Current notebooks can't use RenderHook because it can't import interactive-demos/colab_utils.py.
And I fixed them for enabling to choose GPU mode as default setting.