### PR TITLE
Add noisy net implementation

### DIFF
--- a/docs/source/nnablarl_api.rst
+++ b/docs/source/nnablarl_api.rst
@@ -11,4 +11,6 @@ nnablaRL APIs
     nnablarl_api/functions.rst
     nnablarl_api/hooks.rst
     nnablarl_api/models.rst
+    nnablarl_api/parametric_functions.rst
     nnablarl_api/replay_buffers.rst
+    

--- a/docs/source/nnablarl_api/parametric_functions.rst
+++ b/docs/source/nnablarl_api/parametric_functions.rst
@@ -1,0 +1,7 @@
+=========
+Parametric functions
+=========
+
+.. automodule:: nnabla_rl.parametric_functions
+
+.. autofunction:: noisy_net

--- a/nnabla_rl/initializers.py
+++ b/nnabla_rl/initializers.py
@@ -68,7 +68,7 @@ def LeCunNormal(inmaps, outmaps, kernel=(1, 1), factor=1.0, mode='fan_in'):
     return NI.NormalInitializer(s)
 
 
-def HeUniform(inmaps, outmaps, kernel=(1, 1), factor=2.0, mode='fan_in'):
+def HeUniform(inmaps, outmaps, kernel=(1, 1), factor=2.0, mode='fan_in', rng=None):
     ''' Create Weight initializer proposed by He et al. (Uniform distribution version)
 
     Args:
@@ -90,12 +90,12 @@ def HeUniform(inmaps, outmaps, kernel=(1, 1), factor=2.0, mode='fan_in'):
     else:
         raise NotImplementedError('Unknown init mode: {}'.format(mode))
 
-    return NI.UniformInitializer(lim=(-lim, lim))
+    return NI.UniformInitializer(lim=(-lim, lim), rng=rng)
 
 
-def GlorotUniform(inmaps, outmaps, kernel=(1, 1)):
+def GlorotUniform(inmaps, outmaps, kernel=(1, 1), rng=None):
     lb, ub = NI.calc_uniform_lim_glorot(inmaps, outmaps, kernel)
-    return NI.UniformInitializer(lim=(lb, ub))
+    return NI.UniformInitializer(lim=(lb, ub), rng=rng)
 
 
 class NormcInitializer(NI.BaseInitializer):

--- a/nnabla_rl/parametric_functions.py
+++ b/nnabla_rl/parametric_functions.py
@@ -1,0 +1,139 @@
+# Copyright 2021 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable, Optional, Tuple
+
+import numpy as np
+
+import nnabla as nn
+import nnabla.functions as NF
+import nnabla_rl.functions as RF
+from nnabla.initializer import ConstantInitializer
+from nnabla.parameter import get_parameter_or_create
+from nnabla_rl.initializers import HeUniform
+
+
+def noisy_net(inp: nn.Variable,
+              n_outmap: int,
+              base_axis: int = 1,
+              w_init: Optional[Callable[[Tuple[int, ...]], np.ndarray]] = None,
+              b_init: Optional[Callable[[Tuple[int, ...]], np.ndarray]] = None,
+              noisy_w_init: Optional[Callable[[Tuple[int, ...]], np.ndarray]] = None,
+              noisy_b_init: Optional[Callable[[Tuple[int, ...]], np.ndarray]] = None,
+              fix_parameters: bool = False,
+              rng: Optional[np.random.RandomState] = None,
+              with_bias: bool = True,
+              with_noisy_bias: bool = True,
+              apply_w: Optional[Callable[[nn.Variable], nn.Variable]] = None,
+              apply_b: Optional[Callable[[nn.Variable], nn.Variable]] = None,
+              apply_noisy_w: Optional[Callable[[nn.Variable], nn.Variable]] = None,
+              apply_noisy_b: Optional[Callable[[nn.Variable], nn.Variable]] = None,
+              seed: int = -1) -> nn.Variable:
+    '''
+    Noisy linear layer with factorized gaussian noise  proposed by Fortunato et al. in the paper
+    "Noisy networks for exploration". See: https://arxiv.org/abs/1706.10295 for details.
+
+    Args:
+        inp (nn.Variable): Input of the layer n_outmaps (int): output dimension of the layer.
+        n_outmap (int): Output dimension of the layer.
+        base_axis (int): Axis of the input to treat as sample dimensions. Dimensions up to base_axis will be treated
+            as sample dimensions. Defaults to 1.
+        w_init (None or Callable[[Tuple[int, ...]], np.ndarray]): Initializer of weights used in deterministic stream.
+            Defaults to None. If None, will be initialized with Uniform distribution
+            :math:`(-\\frac{1}{\\sqrt{fanin}},\\frac{1}{\\sqrt{fanin}})`.
+        b_init (None or Callable[[Tuple[int, ...]], np.ndarray]): Initializer of bias used in deterministic stream.
+            Defaults to None. If None, will be initialized with Uniform distribution
+            :math:`(-\\frac{1}{\\sqrt{fanin}},\\frac{1}{\\sqrt{fanin}})`.
+        noisy_w_init (None or Callable[[Tuple[int, ...]], np.ndarray]): Initializer of weights used in noisy stream.
+            Defaults to None. If None, will be initialized to a constant value of :math:`\\frac{0.5}{\\sqrt{fanin}}`.
+        noisy_b_init (None or Callable[[Tuple[int, ...]], np.ndarray]): Initializer of bias used in noisy stream.
+            Defaults to None. If None, will be initialized to a constant value of :math:`\\frac{0.5}{\\sqrt{fanin}}`.
+        fix_parameters (bool): If True, underlying weight and bias parameters will Not be updated during training.
+            Default to False.
+        rng (None or np.random.RandomState): Random number generator for parameter initializer. Defaults to None.
+        with_bias (bool): If True, deterministic bias term is included in the computation. Defaults to True.
+        with_noisy_bias (bool): If True, noisy bias term is included in the computation. Defaults to True.
+        apply_w (None or Callable[[nn.Variable], nn.Variable]): Callable object to apply to the weights on
+            initialization. Defaults to None.
+        apply_b (None or Callable[[nn.Variable], nn.Variable]): Callable object to apply to the bias on
+            initialization. Defaults to None.
+        apply_noisy_w (None or Callable[[nn.Variable], nn.Variable]):  Callable object to apply to the noisy weight on
+            initialization. Defaults to None.
+        apply_noisy_b (None or Callable[[nn.Variable], nn.Variable]):  Callable object to apply to the noisy bias on
+            initialization. Defaults to None.
+        seed (int): Random seed. If -1, seed will be sampled from global random number generator. Defaults to -1.
+
+    Returns:
+        nn.Variable: Linearly transformed input with noisy weights
+    '''
+
+    inmaps = int(np.prod(inp.shape[base_axis:]))
+    if w_init is None:
+        w_init = HeUniform(inmaps, n_outmap, factor=1.0/3.0, rng=rng)
+    if noisy_w_init is None:
+        noisy_w_init = ConstantInitializer(0.5 / np.sqrt(inmaps))
+    w = get_parameter_or_create("W", (inmaps, n_outmap), w_init, True, not fix_parameters)
+    if apply_w is not None:
+        w = apply_w(w)
+
+    noisy_w = get_parameter_or_create("noisy_W", (inmaps, n_outmap), noisy_w_init, True, not fix_parameters)
+    if apply_noisy_w is not None:
+        noisy_w = apply_noisy_w(noisy_w)
+
+    b = None
+    if with_bias:
+        if b_init is None:
+            b_init = HeUniform(inmaps, n_outmap, factor=1.0/3.0, rng=rng)
+        b = get_parameter_or_create("b", (n_outmap, ), b_init, True, not fix_parameters)
+        if apply_b is not None:
+            b = apply_b(b)
+
+    noisy_b = None
+    if with_noisy_bias:
+        if noisy_b_init is None:
+            noisy_b_init = ConstantInitializer(0.5 / np.sqrt(inmaps))
+        noisy_b = get_parameter_or_create("noisy_b", (n_outmap, ), noisy_b_init, True, not fix_parameters)
+        if apply_noisy_b is not None:
+            noisy_b = apply_noisy_b(noisy_b)
+
+    def _f(x):
+        return NF.sign(x) * RF.sqrt(NF.abs(x))
+
+    e_i = _f(NF.randn(shape=(1, inmaps, 1), seed=seed))
+    e_j = _f(NF.randn(shape=(1, 1, n_outmap), seed=seed))
+
+    e_w = NF.reshape(NF.batch_matmul(e_i, e_j), shape=noisy_w.shape)
+    e_w.need_grad = False
+    noisy_w = noisy_w * e_w
+    assert noisy_w.shape == w.shape
+
+    if with_noisy_bias:
+        assert isinstance(noisy_b, nn.Variable)
+        e_b = NF.reshape(e_j, shape=noisy_b.shape)
+        e_b.need_grad = False
+        noisy_b = noisy_b * e_b
+        assert noisy_b.shape == (n_outmap,)
+    weight = w + noisy_w
+
+    if with_bias and with_noisy_bias:
+        assert isinstance(b, nn.Variable)
+        assert isinstance(noisy_b, nn.Variable)
+        bias = b + noisy_b
+    elif with_bias:
+        bias = b
+    elif with_noisy_bias:
+        bias = noisy_b
+    else:
+        bias = None
+    return NF.affine(inp, weight, bias, base_axis)

--- a/tests/test_initializers.py
+++ b/tests/test_initializers.py
@@ -98,6 +98,29 @@ class TestInitializers(object):
         with pytest.raises(NotImplementedError):
             RI.HeUniform(inmaps, outmaps, kernel, factor, mode='fan_unknown')
 
+    def test_he_uniform_with_rng(self):
+        inmaps = 10
+        outmaps = 10
+        kernel = (10, 10)
+        factor = 10.0
+        rng = np.random.RandomState(0)
+
+        initializer1 = RI.HeUniform(inmaps, outmaps, kernel, factor, rng=rng)
+        params1 = initializer1(shape=(5, 5))
+
+        rng = np.random.RandomState(0)
+        initializer2 = RI.HeUniform(inmaps, outmaps, kernel, factor, rng=rng)
+        params2 = initializer2(shape=(5, 5))
+
+        assert np.allclose(params1, params2)
+
+        rng = np.random.RandomState(1)
+        initializer3 = RI.HeUniform(inmaps, outmaps, kernel, factor, rng=rng)
+        params3 = initializer3(shape=(5, 5))
+
+        assert not np.allclose(params1, params3)
+        assert not np.allclose(params2, params3)
+
     def test_lecun_normal_unknown_mode(self):
         inmaps = 10
         outmaps = 10

--- a/tests/test_parametric_functions.py
+++ b/tests/test_parametric_functions.py
@@ -1,0 +1,136 @@
+# Copyright 2021 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+import nnabla as nn
+import nnabla.functions as NF
+import nnabla_rl.parametric_functions as RPF
+
+
+class TestFunctions(object):
+    def setup_method(self, method):
+        nn.clear_parameters()
+
+    def test_noisy_net_forward(self):
+        nn.seed(0)
+        x = nn.Variable.from_numpy_array(np.random.normal(size=(5, 5)))
+        with nn.parameter_scope('noisy1'):
+            y1 = RPF.noisy_net(x, n_outmap=10, seed=1)
+            y1_params = nn.get_parameters()
+        assert y1.shape == (5, 10)
+
+        nn.seed(0)
+        with nn.parameter_scope('noisy2'):
+            y2 = RPF.noisy_net(x, n_outmap=10, seed=1)
+            y2_params = nn.get_parameters()
+        assert y1.shape == y2.shape
+        assert y1_params.keys() == y2_params.keys()
+
+        for param_name in ['W', 'noisy_W', 'b', 'noisy_b']:
+            assert param_name in y1_params.keys()
+        nn.forward_all([y1, y2])
+
+        for y1_param, y2_param in zip(y1_params.values(), y2_params.values()):
+            assert np.allclose(y1_param.d, y2_param.d)
+        assert np.allclose(y1.d, y2.d)
+
+    def test_noisy_net_rng(self):
+        rng = np.random.RandomState(seed=0)
+        x = nn.Variable.from_numpy_array(np.random.normal(size=(5, 5)))
+        with nn.parameter_scope('noisy1'):
+            y1 = RPF.noisy_net(x, n_outmap=10, seed=1, rng=rng)
+            y1_params = nn.get_parameters()
+        assert y1.shape == (5, 10)
+
+        rng = np.random.RandomState(seed=0)
+        with nn.parameter_scope('noisy2'):
+            y2 = RPF.noisy_net(x, n_outmap=10, seed=1, rng=rng)
+            y2_params = nn.get_parameters()
+        assert y1.shape == y2.shape
+        assert y1_params.keys() == y2_params.keys()
+
+        for param_name in ['W', 'noisy_W', 'b', 'noisy_b']:
+            assert param_name in y1_params.keys()
+        nn.forward_all([y1, y2])
+
+        for y1_param, y2_param in zip(y1_params.values(), y2_params.values()):
+            assert np.allclose(y1_param.d, y2_param.d)
+        assert np.allclose(y1.d, y2.d)
+
+    def test_noisy_net_backward(self):
+        nn.seed(0)
+        x = nn.Variable.from_numpy_array(np.random.normal(size=(5, 5)))
+        with nn.parameter_scope('noisy1'):
+            y1 = RPF.noisy_net(x, n_outmap=10, seed=1)
+            y1_params = nn.get_parameters()
+        assert y1.shape == (5, 10)
+
+        nn.seed(0)
+        with nn.parameter_scope('noisy2'):
+            y2 = RPF.noisy_net(x, n_outmap=10, seed=1)
+            y2_params = nn.get_parameters()
+        assert y1.shape == y2.shape
+        for y1_param, y2_param in zip(y1_params.values(), y2_params.values()):
+            y1_param.grad.zero()
+            y2_param.grad.zero()
+
+        loss = NF.sum((y1 - 1.0) ** 2 + (y2 - 5.0) ** 2)
+
+        loss.forward()
+        loss.backward()
+
+        for y1_param, y2_param in zip(y1_params.values(), y2_params.values()):
+            assert not np.allclose(y1_param.g, 0)
+            assert not np.allclose(y2_param.g, 0)
+            assert not np.allclose(y1_param.g, y2_param.g)
+
+    def test_noisy_net_base_axis(self):
+        x = nn.Variable.from_numpy_array(np.random.normal(size=(5, 5, 5)))
+        with nn.parameter_scope('noisy1'):
+            y1 = RPF.noisy_net(x, n_outmap=10, seed=1, base_axis=2)
+        assert y1.shape == (5, 5, 10)
+
+    def test_noisy_net_without_deterministic_bias(self):
+        x = nn.Variable.from_numpy_array(np.random.normal(size=(5, 5)))
+        with nn.parameter_scope('noisy1'):
+            y1 = RPF.noisy_net(x, n_outmap=10, seed=1, with_bias=False)
+            params = nn.get_parameters()
+
+        assert y1.shape == (5, 10)
+        assert 'b' not in params.keys()
+        assert 'noisy_b' in params.keys()
+
+    def test_noisy_net_without_noisy_bias(self):
+        x = nn.Variable.from_numpy_array(np.random.normal(size=(5, 5)))
+        with nn.parameter_scope('noisy1'):
+            y1 = RPF.noisy_net(x, n_outmap=10, seed=1, with_noisy_bias=False)
+            params = nn.get_parameters()
+        assert y1.shape == (5, 10)
+        assert 'b' in params.keys()
+        assert 'noisy_b' not in params.keys()
+
+    def test_noisy_net_without_bias(self):
+        x = nn.Variable.from_numpy_array(np.random.normal(size=(5, 5)))
+        with nn.parameter_scope('noisy1'):
+            y1 = RPF.noisy_net(x, n_outmap=10, seed=1, with_bias=False, with_noisy_bias=False)
+            params = nn.get_parameters()
+        assert y1.shape == (5, 10)
+        assert 'b' not in params.keys()
+        assert 'noisy_b' not in params.keys()
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
Implementation of [Noisy net](https://arxiv.org/abs/1706.10295).
Noisy net is used in several reinforcement learning algorithms including [Rainbow](https://arxiv.org/abs/1710.02298)