### PR TITLE
Add categorical double dqn

### DIFF
--- a/nnabla_rl/algorithms/__init__.py
+++ b/nnabla_rl/algorithms/__init__.py
@@ -17,6 +17,7 @@ from nnabla_rl.algorithm import Algorithm, AlgorithmConfig
 from nnabla_rl.algorithms.a2c import A2C, A2CConfig
 from nnabla_rl.algorithms.bcq import BCQ, BCQConfig
 from nnabla_rl.algorithms.bear import BEAR, BEARConfig
+from nnabla_rl.algorithms.categorical_ddqn import CategoricalDDQN, CategoricalDDQNConfig
 from nnabla_rl.algorithms.categorical_dqn import CategoricalDQN, CategoricalDQNConfig
 from nnabla_rl.algorithms.ddpg import DDPG, DDPGConfig
 from nnabla_rl.algorithms.dqn import DQN, DQNConfig
@@ -64,6 +65,7 @@ def get_class_of(name):
 register_algorithm(A2C, A2CConfig)
 register_algorithm(BCQ, BCQConfig)
 register_algorithm(BEAR, BEARConfig)
+register_algorithm(CategoricalDDQN, CategoricalDDQNConfig)
 register_algorithm(CategoricalDQN, CategoricalDQNConfig)
 register_algorithm(DDPG, DDPGConfig)
 register_algorithm(DQN, DQNConfig)

--- a/nnabla_rl/algorithms/categorical_ddqn.py
+++ b/nnabla_rl/algorithms/categorical_ddqn.py
@@ -1,0 +1,83 @@
+# Copyright 2021 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import Union
+
+import gym
+
+import nnabla_rl.model_trainers as MT
+from nnabla_rl.algorithms.categorical_dqn import (CategoricalDQN, CategoricalDQNConfig, DefaultReplayBufferBuilder,
+                                                  DefaultSolverBuilder, DefaultValueDistFunctionBuilder)
+from nnabla_rl.builders import ModelBuilder, ReplayBufferBuilder, SolverBuilder
+from nnabla_rl.environments.environment_info import EnvironmentInfo
+from nnabla_rl.models import ValueDistributionFunction
+from nnabla_rl.utils.misc import sync_model
+
+
+@dataclass
+class CategoricalDDQNConfig(CategoricalDQNConfig):
+    pass
+
+
+class CategoricalDDQN(CategoricalDQN):
+    '''Categorical Double DQN algorithm.
+
+    This class implements the Categorical Double DQN algorithm
+    introduced by M. Bellemare, et al. in the paper: "A Distributional Perspective on Reinfocement Learning"
+    For details see: https://arxiv.org/abs/1707.06887
+
+    Args:
+        env_or_env_info \
+        (gym.Env or :py:class:`EnvironmentInfo <nnabla_rl.environments.environment_info.EnvironmentInfo>`):
+            the environment to train or environment info
+        config (:py:class:`CategoricalDDQNConfig <nnabla_rl.algorithms.categorical_ddqn.CategoricalDDQNConfig>`):
+            configuration of the CategoricalDDQN algorithm
+        value_distribution_builder (:py:class:`ModelBuilder[ValueDistributionFunctionFunction] \
+            <nnabla_rl.builders.ModelBuilder>`): builder of value distribution function models
+        value_distribution_solver_builder (:py:class:`SolverBuilder <nnabla_rl.builders.SolverBuilder>`):
+            builder of value distribution function solvers
+        replay_buffer_builder (:py:class:`ReplayBufferBuilder <nnabla_rl.builders.ReplayBufferBuilder>`):
+            builder of replay_buffer
+    '''
+
+    def __init__(self, env_or_env_info: Union[gym.Env, EnvironmentInfo],
+                 config: CategoricalDQNConfig = CategoricalDDQNConfig(),
+                 value_distribution_builder: ModelBuilder[ValueDistributionFunction]
+                 = DefaultValueDistFunctionBuilder(),
+                 value_distribution_solver_builder: SolverBuilder = DefaultSolverBuilder(),
+                 replay_buffer_builder: ReplayBufferBuilder = DefaultReplayBufferBuilder()):
+        super(CategoricalDDQN, self).__init__(env_or_env_info,
+                                              config=config,
+                                              value_distribution_builder=value_distribution_builder,
+                                              value_distribution_solver_builder=value_distribution_solver_builder,
+                                              replay_buffer_builder=replay_buffer_builder)
+
+    def _setup_value_distribution_function_training(self, env_or_buffer):
+        trainer_config = MT.q_value_trainers.CategoricalDDQNQTrainerConfig(
+            v_min=self._config.v_min,
+            v_max=self._config.v_max,
+            num_atoms=self._config.num_atoms)
+
+        model_trainer = MT.q_value_trainers.CategoricalDDQNQTrainer(
+            train_function=self._atom_p,
+            solvers={self._atom_p.scope_name: self._atom_p_solver},
+            target_function=self._target_atom_p,
+            env_info=self._env_info,
+            config=trainer_config)
+
+        # NOTE: Copy initial parameters after setting up the training
+        # Because the parameter is created after training graph construction
+        sync_model(self._atom_p, self._target_atom_p)
+        return model_trainer

--- a/nnabla_rl/model_trainers/q_value/__init__.py
+++ b/nnabla_rl/model_trainers/q_value/__init__.py
@@ -16,6 +16,8 @@ from nnabla_rl.model_trainers.q_value.bcq_q_trainer import (  # noqa
     BCQQTrainer, BCQQTrainerConfig)
 from nnabla_rl.model_trainers.q_value.categorical_dqn_q_trainer import (  # noqa
     CategoricalDQNQTrainer, CategoricalDQNQTrainerConfig)
+from nnabla_rl.model_trainers.q_value.categorical_ddqn_q_trainer import (  # noqa
+    CategoricalDDQNQTrainer, CategoricalDDQNQTrainerConfig)
 from nnabla_rl.model_trainers.q_value.clipped_double_q_trainer import (  # noqa
     ClippedDoubleQTrainer, ClippedDoubleQTrainerConfig)
 from nnabla_rl.model_trainers.q_value.ddpg_q_trainer import (  # noqa

--- a/nnabla_rl/model_trainers/q_value/categorical_ddqn_q_trainer.py
+++ b/nnabla_rl/model_trainers/q_value/categorical_ddqn_q_trainer.py
@@ -1,0 +1,73 @@
+# Copyright 2021 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import Dict
+
+import numpy as np
+
+import nnabla as nn
+import nnabla.functions as NF
+from nnabla_rl.environments.environment_info import EnvironmentInfo
+from nnabla_rl.model_trainers.model_trainer import TrainingVariables
+from nnabla_rl.model_trainers.q_value.categorical_dqn_q_trainer import (CategoricalDQNQTrainer,
+                                                                        CategoricalDQNQTrainerConfig)
+from nnabla_rl.models import ValueDistributionFunction
+
+
+@dataclass
+class CategoricalDDQNQTrainerConfig(CategoricalDQNQTrainerConfig):
+    pass
+
+
+class CategoricalDDQNQTrainer(CategoricalDQNQTrainer):
+    # type declarations to type check with mypy
+    # NOTE: declared variables are instance variable and NOT class variable, unless it is marked with ClassVar
+    # See https://mypy.readthedocs.io/en/stable/class_basics.html for details
+    _target_function: ValueDistributionFunction
+
+    def __init__(self,
+                 train_function: ValueDistributionFunction,
+                 solvers: Dict[str, nn.solver.Solver],
+                 target_function: ValueDistributionFunction,
+                 env_info: EnvironmentInfo,
+                 config: CategoricalDDQNQTrainerConfig = CategoricalDDQNQTrainerConfig()):
+        self._train_function = train_function
+        self._target_function = target_function
+        super(CategoricalDDQNQTrainer, self).__init__(train_function, solvers, target_function, env_info, config)
+
+    def _compute_target(self, training_variables: TrainingVariables, **kwargs) -> nn.Variable:
+        batch_size = training_variables.batch_size
+        gamma = training_variables.gamma
+        reward = training_variables.reward
+        non_terminal = training_variables.non_terminal
+        s_next = training_variables.s_next
+
+        N = self._target_function._n_atom
+        v_max = self._config.v_max
+        v_min = self._config.v_min
+
+        a_next = self._train_function.as_q_function().argmax_q(s_next)
+        pj = self._target_function.probs(s_next, a_next)
+
+        delta_z = (v_max - v_min) / (N - 1)
+        z = np.asarray([v_min + i * delta_z for i in range(N)])
+        z = np.broadcast_to(array=z, shape=(batch_size, N))
+        z = nn.Variable.from_numpy_array(z)
+        target = reward + non_terminal * gamma * z
+        Tz = NF.clip_by_value(target, v_min, v_max)
+        assert Tz.shape == (batch_size, N)
+
+        mi = self._compute_projection(Tz, pj, N, v_max, v_min)
+        return mi

--- a/tests/algorithms/test_categorical_ddqn.py
+++ b/tests/algorithms/test_categorical_ddqn.py
@@ -1,0 +1,105 @@
+# Copyright 2021 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+import nnabla as nn
+import nnabla_rl.algorithms as A
+import nnabla_rl.environments as E
+from nnabla_rl.replay_buffer import ReplayBuffer
+
+
+class TestCategoricalDDQN(object):
+    def setup_method(self, method):
+        nn.clear_parameters()
+
+    def test_algorithm_name(self):
+        dummy_env = E.DummyDiscreteImg()
+        categorical_dqn = A.CategoricalDDQN(dummy_env)
+
+        assert categorical_dqn.__name__ == 'CategoricalDDQN'
+
+    def test_continuous_action_env_unsupported(self):
+        '''
+        Check that error occurs when training on continuous action env
+        '''
+
+        dummy_env = E.DummyContinuous()
+        config = A.CategoricalDDQNConfig()
+        with pytest.raises(Exception):
+            A.CategoricalDDQN(dummy_env, config=config)
+
+    def test_run_online_training(self):
+        '''
+        Check that no error occurs when calling online training
+        '''
+
+        dummy_env = E.DummyDiscreteImg()
+        config = A.CategoricalDDQNConfig()
+        config.start_timesteps = 5
+        config.batch_size = 5
+        config.learner_update_frequency = 1
+        config.target_update_frequency = 1
+        categorical_dqn = A.CategoricalDDQN(dummy_env, config=config)
+
+        categorical_dqn.train_online(dummy_env, total_iterations=10)
+
+    def test_run_offline_training(self):
+        '''
+        Check that no error occurs when calling offline training
+        '''
+
+        batch_size = 5
+        dummy_env = E.DummyDiscreteImg()
+        config = A.CategoricalDDQNConfig(batch_size=batch_size)
+        categorical_dqn = A.CategoricalDDQN(dummy_env, config=config)
+
+        experiences = generate_dummy_experiences(dummy_env, batch_size)
+        buffer = ReplayBuffer()
+        buffer.append_all(experiences)
+        categorical_dqn.train_offline(buffer, total_iterations=10)
+
+    def test_compute_eval_action(self):
+        dummy_env = E.DummyDiscreteImg()
+        categorical_dqn = A.CategoricalDDQN(dummy_env)
+
+        state = dummy_env.reset()
+        state = np.float32(state)
+        action = categorical_dqn.compute_eval_action(state)
+
+        assert action.shape == (1, )
+
+    def test_latest_iteration_state(self):
+        '''
+        Check that latest iteration state has the keys and values we expected
+        '''
+
+        dummy_env = E.DummyDiscreteImg()
+        categorical_dqn = A.CategoricalDDQN(dummy_env)
+
+        categorical_dqn._model_trainer_state = {'cross_entropy_loss': 0., 'td_errors': np.array([0., 1.])}
+
+        latest_iteration_state = categorical_dqn.latest_iteration_state
+        assert 'cross_entropy_loss' in latest_iteration_state['scalar']
+        assert 'td_errors' in latest_iteration_state['histogram']
+        assert latest_iteration_state['scalar']['cross_entropy_loss'] == 0.
+        assert np.allclose(latest_iteration_state['histogram']['td_errors'], np.array([0., 1.]))
+
+
+if __name__ == "__main__":
+    from testing_utils import generate_dummy_experiences
+    pytest.main()
+else:
+    from ..testing_utils import generate_dummy_experiences


### PR DESCRIPTION
Add categorical double dqn.
Categorical double dqn is almost same as categorical dqn but computes q value distribution alike double dqn.

Categorical double dqn is used in [Rainbow](https://arxiv.org/abs/1710.02298) algorithm.