### PR TITLE
Fix docs typo

### DIFF
--- a/docs/source/nnablarl_api/functions.rst
+++ b/docs/source/nnablarl_api/functions.rst
@@ -13,7 +13,7 @@ Functions
 .. autofunction:: argmax
 .. autofunction:: quantile_huber_loss
 .. autofunction:: mean_squared_error
-.. autofunction:: minumum_n
+.. autofunction:: minimum_n
 .. autofunction:: gaussian_cross_entropy_method
 .. autofunction:: triangular_matrix
 .. autofunction:: batch_flatten


### PR DESCRIPTION
Fixed the docs typo that had caused sphinx build error.