### PR TITLE
Fix spatial softmax docstring

### DIFF
--- a/nnabla_rl/parametric_functions.py
+++ b/nnabla_rl/parametric_functions.py
@@ -143,7 +143,7 @@ def spatial_softmax(inp: nn.Variable, alpha_init: float = 1., fix_alpha: bool = 
     r''' Spatial softmax layer proposed in https://arxiv.org/abs/1509.06113. Computes
 
     .. math::
-        s_{cij} &= \\frac{\exp(x_{cij} / \\alpha)}{\sum_{i'j'} \exp(x_{ci'j'} / \\alpha)}
+        s_{cij} &= \frac{\exp(x_{cij} / \alpha)}{\sum_{i'j'} \exp(x_{ci'j'} / \alpha)}
 
         f_{cx} &= \sum_{ij} s_{cij}px_{ij}, f_{cy} = \sum_{ij} s_{cij}py_{ij}
 


### PR DESCRIPTION
Fixed spatial softmax docstrings. The fixed result is like

![image](https://user-images.githubusercontent.com/72590119/131424775-66a0e80c-e268-45eb-8952-1597d5dbe0be.png)
