### PR TITLE
Add stop gradient function

### DIFF
--- a/nnabla_rl/functions.py
+++ b/nnabla_rl/functions.py
@@ -1,5 +1,5 @@
 # Copyright 2020,2021 Sony Corporation.
-# Copyright 2021 Sony Group Corporation.
+# Copyright 2021,2022 Sony Group Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -408,3 +408,7 @@ def batch_flatten(x: nn.Variable) -> nn.Variable:
     original_shape = x.shape
     flatten_shape = (original_shape[0], np.prod(original_shape[1:]))
     return NF.reshape(x, shape=flatten_shape)
+
+
+def stop_gradient(variable: nn.Variable) -> nn.Variable:
+    return variable.get_unlinked_variable(need_grad=False)


### PR DESCRIPTION
Add stop gradient function. This is convenient compared to setting need_grad flag to False in below case.

```python
# If you set the flag to False,
x.need_grad = False
# And if you do not need to backprop y->x through this function1
y = function1(x)
# but you want to backprop z->x through this function 2
z = function2(x)
# need_grad = False does not work
```

```python
# stop_gradient will solve the above issue
x_with_grad = x
x_no_grad = stop_gradient(x_with_grad) 
# If you do not need to backprop y->x through this function1
y = function1(x_no_grad)
# but you want to backprop z->x through this function 2
z = function2(x_with_grad)
```
