### PR TITLE
Run PPO on single process when actor num is 1

### DIFF
--- a/tests/algorithms/test_ppo.py
+++ b/tests/algorithms/test_ppo.py
@@ -1,5 +1,5 @@
 # Copyright 2020,2021 Sony Corporation.
-# Copyright 2021 Sony Group Corporation.
+# Copyright 2021,2022 Sony Group Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,6 +51,32 @@ class TestPPO(object):
         dummy_env = E.DummyContinuous()
         actor_timesteps = 10
         actor_num = 2
+        config = A.PPOConfig(batch_size=5, actor_timesteps=actor_timesteps, actor_num=actor_num)
+        ppo = A.PPO(dummy_env, config=config)
+
+        ppo.train_online(dummy_env, total_iterations=actor_timesteps * actor_num)
+
+    def test_run_online_discrete_single_actor(self):
+        '''
+        Check that no error occurs when calling online training (discrete env)
+        '''
+
+        dummy_env = E.DummyDiscreteImg()
+        actor_timesteps = 10
+        actor_num = 1
+        config = A.PPOConfig(batch_size=5, actor_timesteps=actor_timesteps, actor_num=actor_num)
+        ppo = A.PPO(dummy_env, config=config)
+
+        ppo.train_online(dummy_env, total_iterations=actor_timesteps*actor_num)
+
+    def test_run_online_continuous_single_actor(self):
+        '''
+        Check that no error occurs when calling online training (continuous env)
+        '''
+
+        dummy_env = E.DummyContinuous()
+        actor_timesteps = 10
+        actor_num = 1
         config = A.PPOConfig(batch_size=5, actor_timesteps=actor_timesteps, actor_num=actor_num)
         ppo = A.PPO(dummy_env, config=config)
 

--- a/tests/distributions/test_one_hot_softmax.py
+++ b/tests/distributions/test_one_hot_softmax.py
@@ -94,8 +94,8 @@ class TestOneHotSoftmax(object):
         distribution = model.pi(s)
 
         for sample_method in (distribution.sample, distribution.choose_probable):
-            probable = sample_method()
-            loss = NF.mean(probable)
+            value = sample_method()
+            loss = NF.mean(NF.pow_scalar(value, 2.0))
 
             for parameter in model.get_parameters().values():
                 parameter.grad.zero()
@@ -106,7 +106,6 @@ class TestOneHotSoftmax(object):
                 assert np.all(parameter.g == 0)
 
             loss.backward()
-
             for parameter in model.get_parameters().values():
                 assert not np.all(parameter.g == 0)
 


### PR DESCRIPTION
Run PPO on single process when actor num configuration is set to 1.
This prevents creating redundant process which may decrease machine performance.