### PR TITLE
Correct variable to use during rnn training

### DIFF
--- a/nnabla_rl/model_trainers/policy/demme_policy_trainer.py
+++ b/nnabla_rl/model_trainers/policy/demme_policy_trainer.py
@@ -154,7 +154,7 @@ class DEMMEPolicyTrainer(ModelTrainer):
             # Actor optimization graph
             prev_rnn_states = self._prev_policy_rnn_states
             with rnn_support(policy, prev_rnn_states, train_rnn_states, training_variables, self._config):
-                policy_distribution = policy.pi(self._training_variables.s_current)
+                policy_distribution = policy.pi(training_variables.s_current)
             action_var, log_pi = policy_distribution.sample_and_compute_log_prob()
 
             # Q_rr
@@ -162,7 +162,7 @@ class DEMMEPolicyTrainer(ModelTrainer):
             prev_rnn_states = self._prev_q_rr_rnn_states[policy.scope_name]
             for q_function in self._q_rr_functions:
                 with rnn_support(q_function, prev_rnn_states, train_rnn_states, training_variables, self._config):
-                    q_values.append(q_function.q(self._training_variables.s_current, action_var))
+                    q_values.append(q_function.q(training_variables.s_current, action_var))
             self._prev_q_rr_rnn_states[policy.scope_name] = prev_rnn_states
             min_q_rr = RNF.minimum_n(q_values)
 
@@ -171,7 +171,7 @@ class DEMMEPolicyTrainer(ModelTrainer):
             prev_rnn_states = self._prev_q_re_rnn_states[policy.scope_name]
             for q_function in self._q_re_functions:
                 with rnn_support(q_function, prev_rnn_states, train_rnn_states, training_variables, self._config):
-                    q_values.append(q_function.q(self._training_variables.s_current, action_var))
+                    q_values.append(q_function.q(training_variables.s_current, action_var))
             self._prev_q_re_rnn_states[policy.scope_name] = prev_rnn_states
             min_q_re = RNF.minimum_n(q_values)
 

--- a/nnabla_rl/model_trainers/policy/soft_policy_trainer.py
+++ b/nnabla_rl/model_trainers/policy/soft_policy_trainer.py
@@ -178,13 +178,13 @@ class SoftPolicyTrainer(ModelTrainer):
             # Actor optimization graph
             prev_rnn_states = self._prev_policy_rnn_states
             with rnn_support(policy, prev_rnn_states, train_rnn_states, training_variables, self._config):
-                policy_distribution = policy.pi(self._training_variables.s_current)
+                policy_distribution = policy.pi(training_variables.s_current)
             action_var, log_pi = policy_distribution.sample_and_compute_log_prob()
             q_values = []
             prev_rnn_states = self._prev_q_rnn_states[policy.scope_name]
             for q_function in self._q_functions:
                 with rnn_support(q_function, prev_rnn_states, train_rnn_states, training_variables, self._config):
-                    q_values.append(q_function.q(self._training_variables.s_current, action_var))
+                    q_values.append(q_function.q(training_variables.s_current, action_var))
             self._prev_q_rnn_states[policy.scope_name] = prev_rnn_states
             min_q = RNF.minimum_n(q_values)
             self._pi_loss += NF.mean(self.get_temperature() * log_pi - min_q)

--- a/nnabla_rl/model_trainers/q_value/value_distribution_function_trainer.py
+++ b/nnabla_rl/model_trainers/q_value/value_distribution_function_trainer.py
@@ -143,7 +143,7 @@ class ValueDistributionFunctionTrainer(MultiStepTrainer):
                       target: nn.Variable,
                       training_variables: TrainingVariables) -> Tuple[nn.Variable, Dict[str, nn.Variable]]:
         batch_size = training_variables.batch_size
-        atom_probabilities = model.probs(self._training_variables.s_current, self._training_variables.a_current)
+        atom_probabilities = model.probs(training_variables.s_current, training_variables.a_current)
         atom_probabilities = NF.clip_by_value(atom_probabilities, 1e-10, 1.0)
         cross_entropy = target * NF.log(atom_probabilities)
         assert cross_entropy.shape == (batch_size, self._config.num_atoms)


### PR DESCRIPTION
Some training script was using incorrect training_variables when unrolling the network graph.
This PR will fix this issue.