### PR TITLE
Check np_random instance and use correct randint alternative

### DIFF
--- a/nnabla_rl/external/atari_wrappers.py
+++ b/nnabla_rl/external/atari_wrappers.py
@@ -43,6 +43,10 @@ class NoopResetEnv(gym.Wrapper):
         self.noop_max = noop_max
         self.override_num_noops = None
         self.noop_action = 0
+        if hasattr(self.unwrapped.np_random, 'randint'):
+            self._randint = self.unwrapped.np_random.randint
+        else:
+            self._randint = self.unwrapped.np_random.integers
         assert env.unwrapped.get_action_meanings()[0] == 'NOOP'
 
     def reset(self, **kwargs):
@@ -51,7 +55,7 @@ class NoopResetEnv(gym.Wrapper):
         if self.override_num_noops is not None:
             noops = self.override_num_noops
         else:
-            noops = self.unwrapped.np_random.randint(1, self.noop_max + 1)  # pylint: disable=E1101
+            noops = self._randint(1, self.noop_max + 1)  # pylint: disable=E1101
         assert noops > 0
         obs = None
         for _ in range(noops):


### PR DESCRIPTION
I am not sure when this change was made but in some environment, gym.unwrapped.np_random returns Generator instead of RandomState. 

```py
# in case of RandomState
# this line works
gym.unwrapped.np_random.rand_int(...)
# in case of Generator
# rand_int does not exist and we must use integers as an alternative
gym.unwrapped.np_random.integers(...)
```

This PR will fix this issue and chooses correct function for sampling integers.