### PR TITLE
Add gmm and Update gaussian

### DIFF
--- a/nnabla_rl/distributions/distribution.py
+++ b/nnabla_rl/distributions/distribution.py
@@ -1,5 +1,5 @@
 # Copyright 2020,2021 Sony Corporation.
-# Copyright 2021 Sony Group Corporation.
+# Copyright 2021,2022 Sony Group Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,14 +14,16 @@
 # limitations under the License.
 
 from abc import ABCMeta, abstractmethod
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
+
+import numpy as np
 
 import nnabla as nn
 
 
 class Distribution(metaclass=ABCMeta):
     @abstractmethod
-    def sample(self, noise_clip: Optional[Tuple[float, float]] = None) -> nn.Variable:
+    def sample(self, noise_clip: Optional[Tuple[float, float]] = None) -> Union[nn.Variable, np.ndarray]:
         '''
         Sample a value from the distribution.
         If noise_clip is specified, the sampled value will be clipped in the given range.
@@ -32,7 +34,7 @@ class Distribution(metaclass=ABCMeta):
                 float tuple of size 2 which contains the min and max value of the noise.
 
         Returns:
-             nn.Variable: Sampled value
+            Union[nn.Variable, np.ndarray]: Sampled value
         '''
         raise NotImplementedError
 
@@ -43,7 +45,8 @@ class Distribution(metaclass=ABCMeta):
         '''
         raise NotImplementedError
 
-    def sample_multiple(self, num_samples: int, noise_clip: Optional[Tuple[float, float]] = None) -> nn.Variable:
+    def sample_multiple(self, num_samples: int, noise_clip: Optional[Tuple[float, float]] = None
+                        ) -> Union[nn.Variable, np.ndarray]:
         '''
         Sample mutiple value from the distribution
         New axis will be added between the first and second axis.
@@ -59,45 +62,45 @@ class Distribution(metaclass=ABCMeta):
                 float tuple of size 2 which contains the min and max value of the noise.
 
         Returns:
-             nn.Variable: Sampled value.
+            Union[nn.Variable, np.ndarray]: Sampled value.
         '''
         raise NotImplementedError
 
-    def choose_probable(self) -> nn.Variable:
+    def choose_probable(self) -> Union[nn.Variable, np.ndarray]:
         '''
         Compute the most probable action of the distribution
 
         Returns:
-             nnabla.Variable: Probable action of the distribution
+            Union[nn.Variable, np.ndarray]: Probable action of the distribution
         '''
         raise NotImplementedError
 
-    def mean(self) -> nn.Variable:
+    def mean(self) -> Union[nn.Variable, np.ndarray]:
         '''
         Compute the mean of the distribution (if exist)
 
         Returns:
-             nn.Variable: mean of the distribution
+            Union[nn.Variable, np.ndarray]: mean of the distribution
 
         Raises:
              NotImplementedError: The distribution does not have mean
         '''
         raise NotImplementedError
 
-    def log_prob(self, x: nn.Variable) -> nn.Variable:
+    def log_prob(self, x: Union[nn.Variable, np.ndarray]) -> Union[nn.Variable, np.ndarray]:
         '''
         Compute the log probability of given input
 
         Args:
-            x (nn.Variable): Target value to compute the log probability
+            x (Union[nn.Variable, np.ndarray]): Target value to compute the log probability
 
         Returns:
-            nn.Variable: Log probability of given input
+            Union[nn.Variable, np.ndarray]: Log probability of given input
         '''
         raise NotImplementedError
 
     def sample_and_compute_log_prob(self, noise_clip: Optional[Tuple[float, float]] = None) \
-            -> Tuple[nn.Variable, nn.Variable]:
+            -> Union[Tuple[nn.Variable, nn.Variable], Tuple[np.ndarray, np.ndarray]]:
         '''
         Sample a value from the distribution and compute its log probability.
 
@@ -106,20 +109,20 @@ class Distribution(metaclass=ABCMeta):
                 float tuple of size 2 which contains the min and max value of the noise.
 
         Returns:
-            Tuple[nn.Variable, nn.Variable]: Sampled value and its log probabilty
+            Union[Tuple[nn.Variable, nn.Variable], Tuple[np.ndarray, np.ndarray]]: Sampled value and its log probabilty
         '''
         raise NotImplementedError
 
-    def entropy(self) -> nn.Variable:
+    def entropy(self) -> Union[nn.Variable, np.ndarray]:
         '''
         Compute the entropy of the distribution
 
         Returns:
-            nn.Variable: Entropy of the distribution
+            Union[nn.Variable, np.ndarray]: Entropy of the distribution
         '''
         raise NotImplementedError
 
-    def kl_divergence(self, q: 'Distribution') -> nn.Variable:
+    def kl_divergence(self, q: 'Distribution') -> Union[nn.Variable, np.ndarray]:
         '''
         Compute the kullback leibler divergence between given distribution.
         This function will compute KL(self||q)
@@ -128,7 +131,7 @@ class Distribution(metaclass=ABCMeta):
             q(nnabla_rl.distributions.Distribution): target distribution to compute the kl_divergence
 
         Returns:
-            nn.Variable: Kullback leibler divergence
+            Union[nn.Variable, np.ndarray]: Kullback leibler divergence
 
         Raises:
             ValueError: target distribution's type does not match with current distribution type.

--- a/nnabla_rl/distributions/gaussian.py
+++ b/nnabla_rl/distributions/gaussian.py
@@ -1,5 +1,5 @@
 # Copyright 2020,2021 Sony Corporation.
-# Copyright 2021 Sony Group Corporation.
+# Copyright 2021,2022 Sony Group Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import warnings
+from typing import Union
 
 import numpy as np
 
@@ -32,13 +35,65 @@ class Gaussian(Distribution):
         ln_var (nn.Variable): logarithm of the variance :math:`\\sigma^{2}`. (i.e. ln_var is :math:`\\log{\\sigma^{2}}`)
     '''
 
-    def __init__(self, mean, ln_var):
-        super(Gaussian, self).__init__()
-        if not isinstance(mean, nn.Variable):
-            mean = nn.Variable.from_numpy_array(mean)
-        if not isinstance(ln_var, nn.Variable):
-            ln_var = nn.Variable.from_numpy_array(ln_var)
+    _delegate: Union["NumpyGaussian", "NnablaGaussian"]
 
+    def __init__(self, mean: Union[nn.Variable, np.ndarray], ln_var: Union[nn.Variable, np.ndarray]):
+        super(Gaussian, self).__init__()
+        if isinstance(mean, np.ndarray) and isinstance(ln_var, np.ndarray):
+            warnings.warn(
+                "Numpy ndarrays are given as mean and ln_var.\n"
+                "From v0.12.0, if numpy.ndarray is given, "
+                "all Gaussian class methods return numpy.ndarray not nnabla.Variable")
+            self._delegate = NumpyGaussian(mean, ln_var)
+        elif isinstance(mean, nn.Variable) and isinstance(ln_var, nn.Variable):
+            self._delegate = NnablaGaussian(mean, ln_var)
+        else:
+            raise ValueError(
+                f"Invalid type or a pair of types, mean type is {type(mean)} and ln type is {type(ln_var)}")
+
+    @property
+    def ndim(self):
+        return self._delegate.ndim
+
+    def sample(self, noise_clip=None):
+        return self._delegate.sample(noise_clip)
+
+    def sample_multiple(self, num_samples, noise_clip=None):
+        return self._delegate.sample_multiple(num_samples, noise_clip)
+
+    def sample_and_compute_log_prob(self, noise_clip=None):
+        return self._delegate.sample_and_compute_log_prob(noise_clip)
+
+    def sample_multiple_and_compute_log_prob(self, num_samples, noise_clip=None):
+        return self._delegate.sample_multiple_and_compute_log_prob(num_samples, noise_clip)
+
+    def choose_probable(self):
+        return self._delegate.choose_probable()
+
+    def mean(self):
+        return self._delegate.mean()
+
+    def var(self):
+        return self._delegate.var()
+
+    def log_prob(self, x):
+        return self._delegate.log_prob(x)
+
+    def entropy(self):
+        return self._delegate.entropy()
+
+    def kl_divergence(self, q):
+        assert isinstance(q, Gaussian)
+        return self._delegate.kl_divergence(q._delegate)
+
+
+class NnablaGaussian(Distribution):
+    _mean: nn.Variable
+    _var: nn.Variable
+
+    def __init__(self, mean: nn.Variable, ln_var: nn.Variable):
+        super(Distribution, self).__init__()
+        assert mean.shape == ln_var.shape
         self._mean = mean
         self._var = NF.exp(ln_var)
         self._ln_var = ln_var
@@ -88,6 +143,9 @@ class Gaussian(Distribution):
     def mean(self):
         return self._mean
 
+    def var(self):
+        return self._var
+
     def log_prob(self, x):
         return common_utils.gaussian_log_prob(x, self._mean, self._var, self._ln_var)
 
@@ -95,8 +153,66 @@ class Gaussian(Distribution):
         return NF.sum(0.5 + 0.5 * np.log(2.0 * np.pi) + 0.5 * self._ln_var, axis=1, keepdims=True)
 
     def kl_divergence(self, q):
-        assert isinstance(q, Gaussian)
+        assert isinstance(q, NnablaGaussian)
         p = self
         return 0.5 * NF.sum(q._ln_var - p._ln_var + (p._var + (p._mean - q._mean) ** 2.0) / q._var - 1,
                             axis=1,
                             keepdims=True)
+
+
+class NumpyGaussian(Distribution):
+    _mean: np.ndarray
+    _var: np.ndarray
+
+    def __init__(self, mean: np.ndarray, ln_var: np.ndarray) -> None:
+        super(Distribution, self).__init__()
+        self._dim = mean.shape[0]
+        assert (self._dim, ) == mean.shape
+        assert (self._dim, self._dim) == ln_var.shape
+        self._mean = mean
+        self._var = np.exp(ln_var)
+        self._inv_var = np.linalg.inv(self._var)
+
+    def log_prob(self, x):
+        log_det_term = np.log(np.linalg.det(2.0 * np.pi * self._var))
+        diff = self._mean - x
+        quadratic_term = diff.T.dot(self._inv_var).dot(diff)
+        return -0.5 * (log_det_term + quadratic_term)
+
+    def mean(self):
+        return self._mean
+
+    def var(self):
+        return self._var
+
+    def sample(self, noise_clip=None):
+        if noise_clip is not None:
+            raise NotImplementedError
+        return np.random.multivariate_normal(self._mean, self._var)
+
+    def sample_and_compute_log_prob(self, noise_clip=None):
+        raise NotImplementedError
+
+    def sample_multiple(self, num_samples, noise_clip=None):
+        raise NotImplementedError
+
+    def sample_multiple_and_compute_log_prob(self, num_samples, noise_clip=None):
+        raise NotImplementedError
+
+    def kl_divergence(self, q: 'Distribution'):
+        if not isinstance(q, NumpyGaussian):
+            raise NotImplementedError
+
+        p_mean = self._mean
+        p_var = self._var
+
+        q_mean = q.mean()
+        q_var = q.var()
+        q_var_inv = np.linalg.inv(q.var())
+
+        trace_term = np.trace(q_var_inv.dot(p_var))
+        diff = q_mean - p_mean
+        quadratic_term = diff.T.dot(q_var_inv).dot(diff)
+        dimension = self._dim
+        log_det_term = np.log(np.linalg.det(q_var)) - np.log(np.linalg.det(p_var))
+        return 0.5 * (trace_term + quadratic_term - dimension + log_det_term)

--- a/nnabla_rl/distributions/gmm.py
+++ b/nnabla_rl/distributions/gmm.py
@@ -1,0 +1,244 @@
+# Copyright 2022 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TYPE_CHECKING, Optional, Tuple, Union, cast
+
+import numpy as np
+from scipy import linalg
+
+import nnabla as nn
+from nnabla_rl.distributions.distribution import Distribution
+
+if TYPE_CHECKING:
+    from nnabla_rl.numpy_models.distribution_parameters.gmm_parameter import GMMParameter
+
+
+class GMM(Distribution):
+    '''
+    Gaussian Mixture Model distribution
+
+    :math:`\\Sum_{k=1}^{N} \\pi_k \\mathcal{N}(\\mu,\\,\\Sigma)`
+
+    Args:
+        means (Union[nn.Variable, np.ndarray]): means of each gaussian distribution :math:`\\mu_k`.
+        covariances (Union[nn.Variable, np.ndarray]): covariances of each gaussian distribution. :math:`\\Sigma_k`.
+        mixing_coefficients (Union[nn.Variable, np.ndarray]):
+            mixing coefficients of each gaussian distribution. :math:`\\pi_k`.
+    '''
+
+    def __init__(self,
+                 means: Union[nn.Variable, np.ndarray],
+                 covariances: Union[nn.Variable, np.ndarray],
+                 mixing_coefficients: Union[nn.Variable, np.ndarray]):
+        super(GMM, self).__init__()
+        if (
+            isinstance(means, np.ndarray) and
+            isinstance(covariances, np.ndarray) and
+            isinstance(mixing_coefficients, np.ndarray)
+        ):
+            self._delegate = NumpyGMM(means, covariances, mixing_coefficients)
+        elif (
+            isinstance(means, nn.Variable) and
+            isinstance(covariances, nn.Variable) and
+            isinstance(mixing_coefficients, nn.Variable)
+        ):
+            raise NotImplementedError
+        else:
+            raise ValueError(
+                "Invalid type or a set of types.\n"
+                f"means type is {type(means)}, "
+                f"covariances type is {type(covariances)} and"
+                f"mixing_coefficients type is {type(mixing_coefficients)}")
+
+    def sample(self, noise_clip=None):
+        raise self._delegate.sample(noise_clip)
+
+    @property
+    def num_classes(self):
+        return self._delegate.num_classes
+
+    def log_prob(self, x):
+        return self._delegate.log_prob(x)
+
+    def mean(self):
+        return self._delegate.mean()
+
+    def covariance(self):
+        return self._delegate.covariance()
+
+
+class NumpyGMM(Distribution):
+    _means: np.ndarray
+    _covariances: np.ndarray
+    _mixing_coefficients: np.ndarray
+
+    def __init__(self, means: np.ndarray, covariances: np.ndarray, mixing_coefficients: np.ndarray) -> None:
+        super(NumpyGMM, self).__init__()
+        self._num_classes, self._dim = means.shape
+        assert (self._num_classes, self._dim, self._dim) == covariances.shape
+        assert (self._num_classes, ) == mixing_coefficients.shape
+        self._means = means  # shape (num_classes, dim)
+        self._covariances = covariances  # shape (num_classes, dim, dim)
+        self._mixing_coefficients = mixing_coefficients  # shape(num_classes, )
+
+    @staticmethod
+    def from_gmm_parameter(parameter: 'GMMParameter') -> 'NumpyGMM':
+        return NumpyGMM(parameter._means, parameter._covariances, parameter._mixing_coefficients)
+
+    def sample(self, noise_clip=None):
+        if noise_clip is not None:
+            raise NotImplementedError
+        sample_class = np.random.choice(self._num_classes, p=self._mixing_coefficients)
+        return np.random.multivariate_normal(self._means[sample_class], self._covariances[sample_class])
+
+    @property
+    def num_classes(self):
+        return self._num_classes
+
+    def log_prob(self, x):
+        '''compute log observation probabilities of each data under current parameters
+
+        Args:
+            x (np.ndarray): data, shape(num_data, dim)
+
+        Returns:
+            np.ndarray: log observation probabilities of each data
+        '''
+        num_samples, dim = x.shape
+        assert self._dim == dim
+        # compute constant part of multiple gaussian log prob
+        log_probs = -0.5 * np.ones((num_samples, self._num_classes)) * self._dim * np.log(2 * np.pi)
+
+        for i in range(self._num_classes):
+            mean, covs = self._means[i], self._covariances[i]
+
+            # compute determinant of cov marix with cholesky decomposition
+            cholesky_decomposed_cov = linalg.cholesky(covs, lower=True)
+            log_probs[:, i] -= np.sum(np.log(np.diag(cholesky_decomposed_cov)))
+
+            # compute quadratic form value without solving inverse matrix
+            diff = (x - mean).T  # shape (dim, num_data)
+            diff_inv_cholesky_decomposed_cov = linalg.solve_triangular(cholesky_decomposed_cov, diff, lower=True)
+            log_probs[:, i] -= 0.5 * np.sum(diff_inv_cholesky_decomposed_cov ** 2, axis=0)
+
+        log_probs += np.log(self._mixing_coefficients)
+        return log_probs
+
+    def mean(self):
+        mean, _ = compute_mean_and_covariance(self)
+        return mean
+
+    def covariance(self):
+        _, covariance = compute_mean_and_covariance(self)
+        return covariance
+
+
+def compute_responsibility(data: np.ndarray, distribution: NumpyGMM) -> Tuple[np.ndarray, np.ndarray]:
+    '''compute responsibility under current parameters
+
+    Args:
+        data (np.ndarray): data, shape(num_data, dim)
+        distribution (NumpyGMM): distribution
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray]: observation probability, responsibility
+    '''
+    log_probs = distribution.log_prob(data)
+    log_responsibility = log_probs - logsumexp(log_probs, axis=1, keepdims=True)  # shape (num_data, num_classes)
+
+    return np.exp(log_probs), np.exp(log_responsibility)
+
+
+def compute_mean_and_covariance(distribution: NumpyGMM,
+                                mixing_coefficients: Optional[np.ndarray] = None) -> Tuple[np.ndarray, np.ndarray]:
+    '''compute mean and covariance of gmm
+
+    Args:
+        distribution (NumpyGMM): distribution
+        mixing_coefficients (Optional[np.ndarray]): mixing coefficient, if not given, use current mixing coefficient
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray]: mean and var of gmm under current parameters
+    '''
+    if mixing_coefficients is None:
+        # sum of all class's mean, shape (dim, )
+        mean = np.sum(distribution._means *
+                      distribution._mixing_coefficients[:, np.newaxis], axis=0)
+    else:
+        # sum of all class's mean, shape (dim, )
+        mean = np.sum(distribution._means * mixing_coefficients[:, np.newaxis], axis=0)
+
+    # diff.shape = (num_classes, dim)
+    diff = distribution._means - mean[np.newaxis, :]
+    # diff.shape = (num_classes, dim, dim)
+    diff = distribution._means[:, np.newaxis] * diff[:, :, np.newaxis]
+    # mixing_coefficients.shape = (num_classes, 1, 1)
+    mixing_coefficients = distribution._mixing_coefficients[:, np.newaxis, np.newaxis]
+    # covariance.shape = (dim, dim)
+    covariance = np.sum((distribution._covariances + diff) * mixing_coefficients, axis=0)
+    return mean, covariance
+
+
+def compute_mixing_coefficient(responsibility: np.ndarray) -> np.ndarray:
+    '''compute mixing coefficient from the given responsibility
+
+    Args:
+        responsibility (np.ndarray): responsibility, shape(num_data, num_classes)
+
+    Returns:
+        np.ndarray: mixing_coefficients
+    '''
+    num_data, _ = responsibility.shape
+    # shape (num_classes, )
+    log_mixing_coefficients = logsumexp(np.log(responsibility), axis=0, keepdims=True) - np.log(num_data)
+    return cast(np.ndarray, np.exp(log_mixing_coefficients.flatten()))
+
+
+def inference_data_mean_and_covariance(data: np.ndarray, distribution: NumpyGMM) -> Tuple[np.ndarray, np.ndarray]:
+    '''inference mean and covariance of given data
+
+    Args:
+        data (np.ndarray): data, shape(num_data, dim)
+        distribution (NumpyGMM): distribution
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray]: mean and var of data
+    '''
+    _, responsibility = compute_responsibility(data, distribution)
+    mixing_coefficients = compute_mixing_coefficient(responsibility)
+    mean, covariance = compute_mean_and_covariance(distribution, mixing_coefficients)
+    return mean, covariance
+
+
+def logsumexp(x: np.ndarray, axis: int = 0, keepdims: bool = False) -> np.ndarray:
+    r'''compute log sum exp value of the input
+
+    .. math::
+        y = \log (\Sigma (\exp (input)))
+
+    Args:
+        x (np.ndarray): input
+        axis (int): base axis of log sum operation
+        keepdims (bool): flag whether the reduced axes are kept as a dimension with 1 element
+
+    Returns:
+        np.ndarray: log sum exp value of the input
+    '''
+    max_x = np.max(x, axis=axis, keepdims=True)
+    max_x[max_x == -float('inf')] = 0.
+    if keepdims:
+        return cast(np.ndarray, np.log(np.sum(np.exp(x-max_x), axis=axis, keepdims=keepdims)) + max_x)
+    else:
+        return cast(np.ndarray, np.log(np.sum(np.exp(x-max_x),
+                                              axis=axis, keepdims=keepdims)) + np.squeeze(max_x, axis=axis))

--- a/nnabla_rl/model_trainers/encoder/kld_variational_auto_encoder_trainer.py
+++ b/nnabla_rl/model_trainers/encoder/kld_variational_auto_encoder_trainer.py
@@ -92,8 +92,10 @@ class KLDVariationalAutoEncoderTrainer(ModelTrainer):
                                                                               action=training_variables.a_current)
 
             latent_shape = (batch_size, latent_distribution.ndim)
-            target_latent_distribution = Gaussian(mean=np.zeros(shape=latent_shape, dtype=np.float32),
-                                                  ln_var=np.zeros(shape=latent_shape, dtype=np.float32))
+            target_latent_distribution = Gaussian(
+                mean=nn.Variable.from_numpy_array(np.zeros(shape=latent_shape, dtype=np.float32)),
+                ln_var=nn.Variable.from_numpy_array(np.zeros(shape=latent_shape, dtype=np.float32))
+            )
 
             reconstruction_loss = RNF.mean_squared_error(training_variables.a_current, reconstructed_action)
             kl_divergence = latent_distribution.kl_divergence(target_latent_distribution)

--- a/nnabla_rl/models/classic_control/policies.py
+++ b/nnabla_rl/models/classic_control/policies.py
@@ -1,5 +1,5 @@
 # Copyright 2020,2021 Sony Corporation.
-# Copyright 2021 Sony Group Corporation.
+# Copyright 2021,2022 Sony Group Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -88,4 +88,5 @@ class REINFORCEContinousPolicy(StochasticPolicy):
             z = NPF.affine(h, n_outmaps=self._action_dim,
                            name="linear3", w_init=RI.HeNormal(s.shape[1], 200))
 
-        return D.Gaussian(z, np.tile(self._fixed_ln_var, (batch_size, 1)))
+        ln_var = nn.Variable.from_numpy_array(np.tile(self._fixed_ln_var, (batch_size, 1)))
+        return D.Gaussian(z, ln_var)

--- a/nnabla_rl/numpy_model_trainers/__init__.py
+++ b/nnabla_rl/numpy_model_trainers/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nnabla_rl/numpy_model_trainers/distribution_parameters/__init__.py
+++ b/nnabla_rl/numpy_model_trainers/distribution_parameters/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nnabla_rl/numpy_model_trainers/distribution_parameters/gmm_parameter_trainer.py
+++ b/nnabla_rl/numpy_model_trainers/distribution_parameters/gmm_parameter_trainer.py
@@ -1,0 +1,96 @@
+# Copyright 2022 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import numpy as np
+
+from nnabla_rl.distributions.gmm import NumpyGMM, compute_mixing_coefficient, compute_responsibility, logsumexp
+from nnabla_rl.logger import logger
+from nnabla_rl.numpy_model_trainers.numpy_model_trainer import NumpyModelTrainer, NumpyModelTrainerConfig
+from nnabla_rl.numpy_models.distribution_parameters.gmm_parameter import GMMParameter
+
+
+@dataclass
+class GMMParameterTrainerConfig(NumpyModelTrainerConfig):
+    '''GMM Trainer Configuration'''
+
+    num_iterations_per_update: int = 1000
+    threshold: float = 1e-12
+
+    def __post_init__(self):
+        super(GMMParameterTrainerConfig, self).__post_init__()
+
+
+class GMMParameterTrainer(NumpyModelTrainer):
+    '''Gaussian Mixture Model Trainer with EM algorithm'''
+
+    # type declarations to type check with mypy
+    # NOTE: declared variables are instance variable and NOT class variable, unless it is marked with ClassVar
+    # See https://mypy.readthedocs.io/en/stable/class_basics.html for details
+    _parameter: GMMParameter
+    _config: GMMParameterTrainerConfig
+
+    def __init__(self,
+                 parameter: GMMParameter,
+                 config: GMMParameterTrainerConfig = GMMParameterTrainerConfig()):
+        super(GMMParameterTrainer, self).__init__(config)
+        self._parameter = parameter
+
+    def update(self, data: np.ndarray) -> None:
+        '''update the parameters of gmm
+
+        Args:
+            data (np.ndarray): data, shape(num_data, dim)
+        '''
+        prev_log_likelihood = -float('inf')
+        for _ in range(self._config.num_iterations_per_update):
+            probs, responsibility = self._e_step(data)
+
+            # for checking convergence
+            log_likelihood = np.sum(logsumexp(np.log(probs), axis=1, keepdims=True))
+            if self._has_converged(log_likelihood, prev_log_likelihood):
+                break
+
+            prev_log_likelihood = log_likelihood
+            self._m_step(data, responsibility)
+
+    def _e_step(self, data: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        return compute_responsibility(data, NumpyGMM.from_gmm_parameter(self._parameter))
+
+    def _m_step(self, data: np.ndarray, responsibility: np.ndarray) -> None:
+        _, dim = data.shape
+        new_mixing_coefficients = compute_mixing_coefficient(responsibility)
+
+        # adding small value to avoid computational error
+        # nk.shape = (num_classes, )
+        nk = np.exp(logsumexp(np.log(responsibility), axis=0)) + 1e-8
+        # new_means.shape = (num_classes, dim)
+        new_means = np.dot(responsibility.T, data) / nk[:, np.newaxis]
+        new_covariances = np.zeros((self._parameter._num_classes, dim, dim))
+
+        for i in range(self._parameter._num_classes):
+            diff = data - new_means[i, :]
+            variance = np.dot(responsibility[:, i] * diff.T, diff) / nk[i]
+            new_covariances[i] = variance + 1e-8 * np.eye(dim)  # for regularization
+
+        self._parameter.update_parameter(new_means, new_covariances, new_mixing_coefficients)
+
+    def _has_converged(self, new_log_likelihood, prev_log_likelihood):
+        if np.abs(new_log_likelihood - prev_log_likelihood) < self._config.threshold:
+            logger.debug('GMM converged before reaching max iterations')
+            return True
+        else:
+            return False

--- a/nnabla_rl/numpy_model_trainers/numpy_model_trainer.py
+++ b/nnabla_rl/numpy_model_trainers/numpy_model_trainer.py
@@ -1,5 +1,4 @@
-# Copyright 2020,2021 Sony Corporation.
-# Copyright 2021,2022 Sony Group Corporation.
+# Copyright 2022 Sony Group Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,10 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nnabla_rl.distributions.distribution import Distribution  # noqa
-from nnabla_rl.distributions.bernoulli import Bernoulli  # noqa
-from nnabla_rl.distributions.squashed_gaussian import SquashedGaussian  # noqa
-from nnabla_rl.distributions.gaussian import Gaussian  # noqa
-from nnabla_rl.distributions.one_hot_softmax import OneHotSoftmax  # noqa
-from nnabla_rl.distributions.softmax import Softmax  # noqa
-from nnabla_rl.distributions.gmm import GMM  # noqa
+from dataclasses import dataclass
+
+from nnabla_rl.configuration import Configuration
+
+
+@dataclass
+class NumpyModelTrainerConfig(Configuration):
+    '''Configuration class for ModelTrainer
+    '''
+
+    def __post_init__(self):
+        super(NumpyModelTrainerConfig, self).__post_init__()
+
+
+class NumpyModelTrainer(object):
+    def __init__(self, config: NumpyModelTrainerConfig):
+        self._config = config

--- a/nnabla_rl/numpy_models/distribution_parameter.py
+++ b/nnabla_rl/numpy_models/distribution_parameter.py
@@ -1,5 +1,4 @@
-# Copyright 2020,2021 Sony Corporation.
-# Copyright 2021,2022 Sony Group Corporation.
+# Copyright 2022 Sony Group Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nnabla_rl.distributions.distribution import Distribution  # noqa
-from nnabla_rl.distributions.bernoulli import Bernoulli  # noqa
-from nnabla_rl.distributions.squashed_gaussian import SquashedGaussian  # noqa
-from nnabla_rl.distributions.gaussian import Gaussian  # noqa
-from nnabla_rl.distributions.one_hot_softmax import OneHotSoftmax  # noqa
-from nnabla_rl.distributions.softmax import Softmax  # noqa
-from nnabla_rl.distributions.gmm import GMM  # noqa
+from abc import ABCMeta
+
+from nnabla_rl.numpy_models.numpy_model import NumpyModel
+
+
+class DistributionParameter(NumpyModel, metaclass=ABCMeta):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def update_parameter(self, *args):
+        raise NotImplementedError

--- a/nnabla_rl/numpy_models/distribution_parameters/__init__.py
+++ b/nnabla_rl/numpy_models/distribution_parameters/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nnabla_rl/numpy_models/distribution_parameters/gmm_parameter.py
+++ b/nnabla_rl/numpy_models/distribution_parameters/gmm_parameter.py
@@ -1,0 +1,75 @@
+# Copyright 2022 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from nnabla_rl.numpy_models.distribution_parameter import DistributionParameter
+
+
+class GMMParameter(DistributionParameter):
+    '''Gaussian Mixture Model Parameter'''
+
+    _means: np.ndarray
+    _covarinces: np.ndarray
+    _mixing_coefficients: np.ndarray
+
+    def __init__(self, means: np.ndarray,
+                 covariances: np.ndarray,
+                 mixing_coefficients: np.ndarray) -> None:
+        super().__init__()
+        self._num_classes, self._dim = means.shape
+        assert (self._num_classes, self._dim, self._dim) == covariances.shape
+        assert (self._num_classes, ) == mixing_coefficients.shape
+        self._means = means
+        self._covariances = covariances
+        self._mixing_coefficients = mixing_coefficients
+
+    @staticmethod
+    def from_data(data: np.ndarray, num_classes: int) -> 'GMMParameter':
+        '''create GMM from data by random class assignnment
+
+        Args:
+            data (np.ndarray): data, shape (num_data, dim)
+            num_classes (int): number of classes
+
+        Returns:
+            GMMParameter: gaussian mixture model parameter
+        '''
+        num_data, dim = data.shape
+
+        mixing_coefficients = 1.0 / num_classes * np.ones(num_classes)
+        means = np.zeros((num_classes, dim))
+        covariances = np.zeros((num_classes, dim, dim))
+
+        # assign random class to data
+        assigned_class = np.random.randint(0, num_classes, size=num_data)
+
+        # compute each class's mean and value
+        for i in range(num_classes):
+            class_idx = np.where(assigned_class == i)[0]
+            mean = np.mean(data[class_idx, :], axis=0)
+            diff = (data[class_idx, :] - mean).T
+            sigma = (1.0 / num_classes) * (diff.dot(diff.T))
+            means[i, :] = mean
+            covariances[i, :, :] = sigma + np.eye(dim) * 1e-8  # add small value to keep positive-definiy
+
+        return GMMParameter(means, covariances, mixing_coefficients)
+
+    def update_parameter(self,  # type: ignore
+                         new_means: np.ndarray,
+                         new_covariances: np.ndarray,
+                         new_mixing_coefficients: np.ndarray) -> None:
+        self._means = new_means
+        self._covariances = new_covariances
+        self._mixing_coefficients = new_mixing_coefficients

--- a/tests/algorithms/test_ppo.py
+++ b/tests/algorithms/test_ppo.py
@@ -34,8 +34,8 @@ class TupleStateActor(StochasticPolicy):
 
     def pi(self, s: nn.Variable):
         s, *_ = s
-        return Gaussian(mean=np.zeros(shape=(s.shape[0], self._action_dim)),
-                        ln_var=np.zeros(shape=(s.shape[0], self._action_dim)))
+        return Gaussian(mean=nn.Variable.from_numpy_array(np.zeros(shape=(s.shape[0], self._action_dim))),
+                        ln_var=nn.Variable.from_numpy_array(np.zeros(shape=(s.shape[0], self._action_dim))))
 
 
 class TupleStateActorBuilder(ModelBuilder[VFunction]):

--- a/tests/distributions/test_gmm.py
+++ b/tests/distributions/test_gmm.py
@@ -1,0 +1,130 @@
+# Copyright 2022 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+import numpy as np
+import pytest
+from scipy import stats
+
+import nnabla as nn
+from nnabla_rl.distributions.gmm import (GMM, NumpyGMM, compute_mean_and_covariance, compute_mixing_coefficient,
+                                         compute_responsibility, inference_data_mean_and_covariance)
+
+
+def _generate_dummy_params():
+    num_classes = 2
+    dims = 1
+    means = np.array([[3.0], [5.0]])
+    covariances = np.array([[[0.4]], [[0.1]]])
+    mixing_coefficients = np.array([0.4, 0.6])
+    return num_classes, dims, means, covariances, mixing_coefficients
+
+
+class TestGMM():
+    def test_nnabla_constructor(self):
+        _, _, means, covariances, mixing_coefficients = _generate_dummy_params()
+        nnabla_means = nn.Variable.from_numpy_array(means)
+        nnabla_covariances = nn.Variable.from_numpy_array(covariances)
+        nnabla_mixing_coefficients = nn.Variable.from_numpy_array(mixing_coefficients)
+        with pytest.raises(NotImplementedError):
+            GMM(nnabla_means, nnabla_covariances, nnabla_mixing_coefficients)
+
+    def test_numpy_constructor(self):
+        _, _, means, covariances, mixing_coefficients = _generate_dummy_params()
+        distribution = GMM(means, covariances, mixing_coefficients)
+        assert isinstance(distribution._delegate, NumpyGMM)
+
+
+class TestNumpyGMM():
+    def test_sample(self):
+        _, dims, means, covariances, mixing_coefficients = _generate_dummy_params()
+        gmm = NumpyGMM(means, covariances, mixing_coefficients)
+        sample = gmm.sample()
+        assert sample.shape == (dims, )
+
+        with pytest.raises(NotImplementedError):
+            gmm.sample(noise_clip=np.ones(means.shape[1:]))
+
+    def test_numpy_log_prob(self):
+        num_classes, dims, means, covariances, mixing_coefficients = _generate_dummy_params()
+        data = np.random.randn(10, dims)
+
+        gmm = NumpyGMM(means, covariances, mixing_coefficients)
+        actual_log_probs = gmm.log_prob(data)
+
+        probs = np.zeros((data.shape[0], num_classes))
+        for k in range(num_classes):
+            probs[:, k] = mixing_coefficients[k] * stats.multivariate_normal.pdf(data, means[k], covariances[k])
+
+        assert np.allclose(actual_log_probs, np.log(probs))
+
+    def test_numpy_compute_responsibility(self):
+        num_classes, dims, means, covariances, mixing_coefficients = _generate_dummy_params()
+        data = np.random.randn(10, dims)
+
+        gmm = NumpyGMM(means, covariances, mixing_coefficients)
+
+        _, actual_responsibility = compute_responsibility(data, gmm)
+
+        probs = np.zeros((data.shape[0], num_classes))
+        for k in range(num_classes):
+            probs[:, k] = mixing_coefficients[k] * stats.multivariate_normal.pdf(data, means[k], covariances[k])
+        denom = np.sum(probs, axis=1, keepdims=True)
+        expected_responsibility = probs / denom
+
+        assert np.allclose(actual_responsibility, expected_responsibility)
+
+    def test_numpy_compute_mixing_coefficient(self):
+        responsibility = np.random.randn(3, 1) + 2.0
+        with mock.patch(
+            'nnabla_rl.distributions.gmm.logsumexp', return_value=1.0
+        ) as mock_logsumexp:
+            result = compute_mixing_coefficient(responsibility)
+            mock_logsumexp.assert_called_once()
+            assert result == np.exp(1 - np.log(responsibility.shape[0]))
+
+    def test_numpy_compute_mean_and_covariance(self):
+        _, _, means, covariances, mixing_coefficients = _generate_dummy_params()
+        gmm = NumpyGMM(means, covariances, mixing_coefficients)
+        actual_mean, actual_var = compute_mean_and_covariance(gmm)
+
+        assert np.allclose(actual_mean, np.array([4.2]))
+        assert np.allclose(actual_var, np.array([[0.4 * 0.4 + 0.6 * 0.1 + 0.4 * 0.6 * (3 - 5) ** 2]]))
+
+    def test_numpy_inference_data_mean_and_covariance(self):
+        _, dims, means, covariances, mixing_coefficients = _generate_dummy_params()
+        data = np.random.randn(10, dims)
+
+        gmm = NumpyGMM(means, covariances, mixing_coefficients)
+
+        with mock.patch(
+            'nnabla_rl.distributions.gmm.compute_responsibility', return_value=(None, None)
+        ) as mock_compute_responsibility:
+            with mock.patch(
+                'nnabla_rl.distributions.gmm.compute_mixing_coefficient', return_value=None
+            ) as mock_compute_mixing_coefficient:
+                with mock.patch(
+                    'nnabla_rl.distributions.gmm.compute_mean_and_covariance',
+                    return_value=(None, None),
+                ) as mock_compute_mean_and_var:
+
+                    inference_data_mean_and_covariance(data, gmm)
+                    mock_compute_responsibility.assert_called_once()
+                    mock_compute_mixing_coefficient.assert_called_once()
+                    mock_compute_mean_and_var.assert_called_once()
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/tests/model_trainers/test_policy_trainers.py
+++ b/tests/model_trainers/test_policy_trainers.py
@@ -1,5 +1,5 @@
 # Copyright 2020,2021 Sony Corporation.
-# Copyright 2021 Sony Group Corporation.
+# Copyright 2021,2022 Sony Group Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -83,7 +83,8 @@ class StochasticRnnPolicy(StochasticPolicy):
 
     def pi(self, s):
         self._fake_internal_state = self._fake_internal_state * 2
-        return Gaussian(mean=np.zeros(s.shape), ln_var=np.ones(s.shape))
+        return Gaussian(mean=nn.Variable.from_numpy_array(np.zeros(s.shape)),
+                        ln_var=nn.Variable.from_numpy_array(np.ones(s.shape)))
 
 
 class TrainerTest(metaclass=ABCMeta):

--- a/tests/numpy_model_trainers/__init__.py
+++ b/tests/numpy_model_trainers/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/numpy_model_trainers/distribution_parameters/test_gmm_parameter_trainer.py
+++ b/tests/numpy_model_trainers/distribution_parameters/test_gmm_parameter_trainer.py
@@ -1,0 +1,84 @@
+# Copyright 2022 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+from nnabla_rl.numpy_model_trainers.distribution_parameters.gmm_parameter_trainer import (GMMParameterTrainer,
+                                                                                          GMMParameterTrainerConfig)
+from nnabla_rl.numpy_models.distribution_parameters.gmm_parameter import GMMParameter
+
+
+def _sample_gaussian(means, covs, num_data):
+    num_classes, dim = means.shape
+    data = []
+    for i in range(num_classes):
+        class_data = np.random.multivariate_normal(means[i], covs[i], size=num_data // num_classes)
+        data.append(class_data)
+    return np.concatenate(data, axis=0)
+
+
+def _is_positive_semidefinite(x):
+    return np.all(np.linalg.eigvals(x) >= 0)
+
+
+class TestGMMParameterTrainer:
+    def test_update(self):
+        # create dummy dataset
+        # sample data
+        mean_1 = np.array([3, -4])
+        cov_1 = np.array([[0.1, 0.0], [0.0, 0.1]])
+        assert _is_positive_semidefinite(cov_1)
+
+        mean_2 = np.array([0.0, 0])
+        cov_2 = np.array([[0.75, 0.15], [0.15, 0.75]])
+        assert _is_positive_semidefinite(cov_2)
+
+        mean_3 = np.array([-5, 6])
+        cov_3 = np.array([[0.5, 0.1], [0.1, 0.5]])
+        assert _is_positive_semidefinite(cov_3)
+
+        means = np.stack([mean_1, mean_2, mean_3], axis=0)
+        covariances = np.stack([cov_1, cov_2, cov_3], axis=0)
+
+        test_success = False
+        # because EM algorithm results strongly depend on the initial parameters, run test multiple times
+        for _ in range(5):
+            data = _sample_gaussian(means, covariances, 5000)
+            trainer = GMMParameterTrainer(
+                parameter=GMMParameter.from_data(data, num_classes=3),
+                config=GMMParameterTrainerConfig(num_iterations_per_update=1000, threshold=1e-12))
+            trainer.update(data)
+
+            order = np.argsort(trainer._parameter._means[:, 0])
+            actual_means = trainer._parameter._means[order]
+            actual_covariances = trainer._parameter._covariances[order]
+            order = np.argsort(means[:, 0])
+            expected_means = means[order]
+            expected_covariances = covariances[order]
+
+            matched = True
+            for actual_mean, actual_covariance, expected_mean, expected_covariance, in zip(
+                    actual_means, actual_covariances, expected_means, expected_covariances):
+                matched &= np.allclose(actual_mean, expected_mean, atol=1e-1)
+                matched &= np.allclose(actual_covariance, expected_covariance, atol=1e-1)
+            if matched:
+                test_success = True
+                break
+
+        assert test_success
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/numpy_models/__init__.py
+++ b/tests/numpy_models/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/numpy_models/distribution_parameters/__init__.py
+++ b/tests/numpy_models/distribution_parameters/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/numpy_models/distribution_parameters/test_gmm_parameter.py
+++ b/tests/numpy_models/distribution_parameters/test_gmm_parameter.py
@@ -1,0 +1,39 @@
+# Copyright 2022 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+from nnabla_rl.numpy_models.distribution_parameters.gmm_parameter import GMMParameter
+
+
+class TestGMMParameter:
+    def test_update_parameters(self):
+        means = np.array([[3.0], [5.0]])
+        covariances = np.array([[[0.4]], [[0.1]]])
+        mixing_coefficients = np.array([0.4, 0.6])
+        gmm_param = GMMParameter(means, covariances, mixing_coefficients)
+
+        new_means = np.array([[20.0], [10.0]])
+        new_covariances = np.array([[[1.8]], [[1.5]]])
+        new_mixing_coefficients = np.array([0.9, 0.1])
+        gmm_param.update_parameter(new_means, new_covariances, new_mixing_coefficients)
+
+        assert np.allclose(new_means, gmm_param._means)
+        assert np.allclose(new_covariances, gmm_param._covariances)
+        assert np.allclose(new_mixing_coefficients, gmm_param._mixing_coefficients)
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -405,7 +405,7 @@ class TestFunctions(object):
             def pi(self, s: nn.Variable):
                 with nn.parameter_scope(self.scope_name):
                     z = NPF.affine(s, n_outmaps=5)
-                return D.Gaussian(z, np.zeros(z.shape))
+                return D.Gaussian(z, nn.Variable.from_numpy_array(np.zeros(z.shape)))
 
         test_model = TestModel('test')
         for parameter in test_model.get_parameters().values():


### PR DESCRIPTION
Added gmm and gaussian of the numpy models.
In addition, updated the gaussian distribution's API.

The API change is like following:
 
Previous :

```py
batch_size = 10
output_dim = 10
input_shape = (batch_size, output_dim)
mean = np.zeros(shape=input_shape)
sigma = np.ones(shape=input_shape) * 5.
ln_var = np.log(sigma) * 2.
distribution = D.Gaussian(mean, ln_var)
# return nn.Variable
assert isinstance(distribution.sample(), nn.Variable)
```

Updated:

```py
batch_size = 10
output_dim = 10
input_shape = (batch_size, output_dim)
mean = np.zeros(shape=input_shape)
sigma = np.ones(shape=input_shape) * 5.
ln_var = np.log(sigma) * 2.
# You have to pass the nn.Variable if you want to get nn.Variable as all class method's return.
distribution = D.Gaussian(nn.Variable.from_numpy_array(mean), nn.Variable.from_numpy_array(ln_var))
assert isinstance(distribution.sample(), nn.Variable)

# If you pass np.ndarray, then all class methods return np.ndarray
# Currently, only support without batch shape (i.e. mean.shape = (dims,), ln_var.shape = (dims, dims)).
distribution = D.Gaussian(mean[0], np.diag(ln_var[0]))  # without batch
assert isinstance(distribution.sample(), np.ndarray)
```
