### PR TITLE
Fix float max/min value range of gaussian explorer

### DIFF
--- a/nnabla_rl/environment_explorers/gaussian_explorer.py
+++ b/nnabla_rl/environment_explorers/gaussian_explorer.py
@@ -13,9 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 from dataclasses import dataclass
-from typing import Dict, Tuple
+from typing import Dict, Tuple, cast
 
 import numpy as np
 
@@ -30,14 +29,14 @@ class GaussianExplorerConfig(EnvironmentExplorerConfig):
 
     Args:
         action_clip_low (float): Minimum noise value. Noise below this value will be clipped.
-            Defaults to sys.float_info.min.
+            Defaults to np.finfo(np.float).min
         action_clip_high (float): Maximum noise value. Noise above this value will be clipped.
-            Defaults to sys.float_info.max.
+            Defaults to np.finfo(np.float).max
         sigma (float): Standard deviation of gaussian noise. Must be positive. Defaults to 1.0.
     """
 
-    action_clip_low: float = sys.float_info.min
-    action_clip_high: float = sys.float_info.max
+    action_clip_low: float = cast(float, np.finfo(np.float32).min)
+    action_clip_high: float = cast(float, np.finfo(np.float32).max)
     sigma: float = 1.0
 
     def __post_init__(self):
@@ -47,7 +46,7 @@ class GaussianExplorerConfig(EnvironmentExplorerConfig):
 class GaussianExplorer(EnvironmentExplorer):
     """Gaussian explorer.
 
-    Explore using policy's action without gaussian noise appended to it. Policy's action must be continuous action.
+    Explore using policy's action with gaussian noise appended to it. Policy's action must be continuous action.
 
     Args:
         policy_action_selector (:py:class:`ActionSelector <nnabla_rl.typing.ActionSelector>`):

--- a/tests/environment_explorers/test_gaussian.py
+++ b/tests/environment_explorers/test_gaussian.py
@@ -1,5 +1,5 @@
 # Copyright 2020,2021 Sony Corporation.
-# Copyright 2021 Sony Group Corporation.
+# Copyright 2021,2022,2023 Sony Group Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,6 +42,27 @@ class TestRandomGaussianActionStrategy(object):
         action, info = explorer.action(steps, state)
 
         assert np.all(clip_low <= action) and np.all(action <= clip_high)
+        assert info['test'] == 'success'
+
+    @pytest.mark.parametrize("sigma", np.arange(start=0.01, stop=5.0, step=1.0))
+    def test_random_gaussian_without_clipping(self, sigma):
+        def policy_action_selector(state, *,  begin_of_episode=False):
+            return np.zeros(shape=state.shape), {'test': 'success'}
+
+        config = GaussianExplorerConfig(
+            sigma=sigma
+        )
+        explorer = GaussianExplorer(
+            env_info=None,
+            policy_action_selector=policy_action_selector,
+            config=config
+        )
+
+        steps = 1
+        state = np.empty(shape=(1, 4))
+        action, info = explorer.action(steps, state)
+
+        assert not np.allclose(action, np.zeros(action.shape))
         assert info['test'] == 'success'
 
 


### PR DESCRIPTION
The Gaussian explorer's np.clip was not functioning as expected when using the default value of action_clip_low.
Because the sys.finfo.min does not represent the minimum value of the float types.

This PR fixes this issue by assigning the correct minimum as the default.