### PR TITLE
Fix pypi deploy workflow and use OIDC

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,23 +5,39 @@ on:
     types: [published]
 
 jobs:
-  deploy:
+  release-build:
     if: github.repository == 'sony/nnabla-rl'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r deploy_requirements.txt
-      - name: Build and upload
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      - name: Build release distributions
         run: |
           python setup.py bdist_wheel
-          twine upload dist/*
+      - name: Temporarily upload release distribution
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-dists
+          path: dist/
+  deploy:
+    if: github.repository == 'sony/nnabla-rl'
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      id-token: write
+    steps:
+      - name: Retrieve temporarily uploaded release distributions
+        uses: actions/download-artifact@v3
+        with:
+          name: release-dists
+          path: dist/
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/deploy_requirements.txt
+++ b/deploy_requirements.txt
@@ -1,4 +1,3 @@
 setuptools
 wheel
-twine
 numpy>=1.17


### PR DESCRIPTION
Use [Trusted Publisher](https://docs.pypi.org/trusted-publishers/) method when uploading to pypi.