### PR TITLE
Avoid raising exception when info has inconsistent values

### DIFF
--- a/nnabla_rl/utils/data.py
+++ b/nnabla_rl/utils/data.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, Generic, Iterable, List, Sequence, Tuple, TypeVar,
 import numpy as np
 
 import nnabla as nn
+from nnabla_rl.logger import logger
 from nnabla_rl.typing import TupledData
 
 T = TypeVar('T')
@@ -77,10 +78,14 @@ def marshal_dict_experiences(dict_experiences: Sequence[Dict[str, Any]]) -> Dict
     dict_of_list = list_of_dict_to_dict_of_list(dict_experiences)
     marshaled_experiences = {}
     for key, data in dict_of_list.items():
-        if isinstance(data[0], Dict):
-            marshaled_experiences.update({key: marshal_dict_experiences(data)})
-        else:
-            marshaled_experiences.update({key: add_axis_if_single_dim(np.asarray(data))})
+        try:
+            if isinstance(data[0], Dict):
+                marshaled_experiences.update({key: marshal_dict_experiences(data)})
+            else:
+                marshaled_experiences.update({key: add_axis_if_single_dim(np.asarray(data))})
+        except ValueError as e:
+            # do nothing
+            logger.warn(f'key: {key} contains inconsistent elements!. Details: {e}')
     return marshaled_experiences
 
 

--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -15,6 +15,7 @@
 
 import numpy as np
 import pytest
+from packaging.version import parse
 
 import nnabla as nn
 import nnabla_rl.environments as E
@@ -131,6 +132,27 @@ class TestData():
         assert len(key2_experiences) == 2
 
         np.testing.assert_allclose(np.asarray(key1_experiences), 1)
+        np.testing.assert_allclose(np.asarray(key2_experiences), 2)
+
+    def test_marashal_dict_experiences_with_inhomogeneous_part(self):
+        installed_numpy_version = parse(np.__version__)
+        numpy_version1_24 = parse('1.24.0')
+
+        if installed_numpy_version < numpy_version1_24:
+            # no need to test
+            return
+
+        experiences = {'key1': 1, 'key2': 2}
+        inhomgeneous_experiences = {'key1': np.empty(shape=(6, )), 'key2': 2}
+        dict_experiences = [{'key_parent': experiences}, {'key_parent': inhomgeneous_experiences}]
+
+        marshaled_experience = marshal_dict_experiences(dict_experiences)
+
+        assert 'key1' not in marshaled_experience['key_parent']
+
+        key2_experiences = marshaled_experience['key_parent']['key2']
+        assert key2_experiences.shape == (2, 1)
+
         np.testing.assert_allclose(np.asarray(key2_experiences), 2)
 
     def test_list_of_dict_to_dict_of_list(self):


### PR DESCRIPTION
Numpy raises error when adding dimensions to an array that has elements of different shapes. (From [numpy >= 1.24.0](https://numpy.org/doc/stable/release/1.24.0-notes.html).)

The above change in the numpy library may raise error in codes that worked properly before numpy 1.24.0.
 
This PR fixes this issue by ignoring the values that has inconsistent shapes when building the batch and alerts the user with warning.