### PR TITLE
Feature/20240911 enable squashed gaussian on ppo

### DIFF
--- a/nnabla_rl/model_trainers/policy/ppo_policy_trainer.py
+++ b/nnabla_rl/model_trainers/policy/ppo_policy_trainer.py
@@ -108,10 +108,12 @@ class PPOPolicyTrainer(ModelTrainer):
             lower_bounds = NF.minimum2(probability_ratio * advantage, clipped_ratio * advantage)
             clip_loss = NF.mean(lower_bounds)
 
-            entropy = distribution.entropy()
-            entropy_loss = NF.mean(entropy)
-
-            self._pi_loss += 0.0 if ignore_loss else (-clip_loss - self._config.entropy_coefficient * entropy_loss)
+            if self._config.entropy_coefficient != 0.0:
+                entropy = distribution.entropy()
+                entropy_loss = NF.mean(entropy)
+                self._pi_loss += 0.0 if ignore_loss else (-clip_loss - self._config.entropy_coefficient * entropy_loss)
+            else:
+                self._pi_loss += 0.0 if ignore_loss else -clip_loss
 
     def _setup_training_variables(self, batch_size) -> TrainingVariables:
         # Training input variables


### PR DESCRIPTION
Some distribution (like SquashedGaussian) does not have an analytical form for the entropy. Thus PPO can not use such distribution in the training.
However, when entropy coefficient of PPO training is 0, ppo does not need to compute the entropy of the policy distribution.
This PR enables using SquashedGaussian and other distributions in PPO when the entropy coefficient is 0. 
New implementation ignores the computation of entropy in policy training with 0 coefficient.