### PR TITLE
Fix github actions error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/nnabla_rl/model_trainers/v_value/v_function_trainer.py
+++ b/nnabla_rl/model_trainers/v_value/v_function_trainer.py
@@ -114,7 +114,7 @@ class VFunctionTrainer(ModelTrainer):
         target_v = self._compute_target(training_variables)
         target_v.need_grad = False
 
-        loss = 0
+        loss = 0.0
         for v_function in models:
             v_function = cast(VFunction, v_function)
             v_loss = self._compute_loss(v_function, target_v, training_variables)


### PR DESCRIPTION
This PR is for fixing the following github actions errros.

## black error

The error is caused by black installation.
From version 24.10.0, black dropped python3.8 supports.

To solve this, I used python `3.9` in `build.yaml`

## mypy error

With the new version of mypy, the test for typing fails.

The solution is to use `0.0` not `0` in `v_function_model_trainer`.

The error message is

```
nnabla_rl/model_trainers/v_value/v_function_trainer.py:127: error: Incompatible types in assignment (expression has type "Union[float, Any]", variable has type "int")  [assignment]
```
